### PR TITLE
Address Lingering Issues with new code

### DIFF
--- a/src/main/java/com/wynprice/noctrl/GuiSelectList.java
+++ b/src/main/java/com/wynprice/noctrl/GuiSelectList.java
@@ -50,7 +50,7 @@ public class GuiSelectList {
         mc.fontRenderer.drawString(NoCtrl.ACTIVE.getName(), this.xPos + 26, this.yPos + CELL_HEIGHT / 2 - 4, -1);
         if(this.open) {
 			//scroll can point beyond what exists
-			this.scroll = Math.min(this.scroll,NoCtrl.ALL_LISTS.size()-CELL_MAX);
+			this.scroll = MathHelper.clamp(this.scroll, 0, Math.max(NoCtrl.ALL_LISTS.size() - CELL_MAX, 0));
             for (int i = 0; i < listedCells; i++) {
                 int actual = i + this.scroll;
                 int yStart = this.yPos + CELL_HEIGHT * (i + 1);

--- a/src/main/java/com/wynprice/noctrl/GuiSelectList.java
+++ b/src/main/java/com/wynprice/noctrl/GuiSelectList.java
@@ -49,6 +49,8 @@ public class GuiSelectList {
         mc.getRenderItem().renderItemIntoGUI(new ItemStack(NoCtrl.ACTIVE.getModel()), this.xPos + 5, this.yPos + 2);
         mc.fontRenderer.drawString(NoCtrl.ACTIVE.getName(), this.xPos + 26, this.yPos + CELL_HEIGHT / 2 - 4, -1);
         if(this.open) {
+			//scroll can point beyond what exists
+			this.scroll = Math.min(this.scroll,NoCtrl.ALL_LISTS.size()-CELL_MAX);
             for (int i = 0; i < listedCells; i++) {
                 int actual = i + this.scroll;
                 int yStart = this.yPos + CELL_HEIGHT * (i + 1);

--- a/src/main/java/com/wynprice/noctrl/GuiSelectList.java
+++ b/src/main/java/com/wynprice/noctrl/GuiSelectList.java
@@ -49,7 +49,7 @@ public class GuiSelectList {
         mc.getRenderItem().renderItemIntoGUI(new ItemStack(NoCtrl.ACTIVE.getModel()), this.xPos + 5, this.yPos + 2);
         mc.fontRenderer.drawString(NoCtrl.ACTIVE.getName(), this.xPos + 26, this.yPos + CELL_HEIGHT / 2 - 4, -1);
         if(this.open) {
-            for (int i = 0; i < CELL_MAX; i++) {
+            for (int i = 0; i < listedCells; i++) {
                 int actual = i + this.scroll;
                 int yStart = this.yPos + CELL_HEIGHT * (i + 1);
                 Gui.drawRect(this.xPos, yStart, this.xPos + CELL_WIDTH, yStart + CELL_HEIGHT, insideSelectionColor);
@@ -93,7 +93,7 @@ public class GuiSelectList {
                         for (int i = 0; i < NoCtrl.ALL_LISTS.size(); i++) {
                             int i1 = i + this.scroll;
                             if(relY <= CELL_HEIGHT * (i1 + 2)) {
-                                NoCtrl.ALL_LISTS.get(i1).setAsCurrent();
+                                NoCtrl.ALL_LISTS.get(i1 + this.scroll).setAsCurrent();
                                 break;
                             }
                         }

--- a/src/main/java/com/wynprice/noctrl/GuiSelectList.java
+++ b/src/main/java/com/wynprice/noctrl/GuiSelectList.java
@@ -92,8 +92,8 @@ public class GuiSelectList {
                     } else if(this.open){
                         for (int i = 0; i < NoCtrl.ALL_LISTS.size(); i++) {
                             int i1 = i + this.scroll;
-                            if(relY <= CELL_HEIGHT * (i1 + 2)) {
-                                NoCtrl.ALL_LISTS.get(i1 + this.scroll).setAsCurrent();
+                            if(relY <= CELL_HEIGHT * (i + 2)) {
+                                NoCtrl.ALL_LISTS.get(i1).setAsCurrent();
                                 break;
                             }
                         }


### PR DESCRIPTION
Small lists would crash because they assumed the list would always be 5 entries long.  Using listedCells instead of CELL_MAX fixes that.

Also, selecting items from a large list wouldn't always work either.  Turns out the wrong index was being used when the list was scrolled.

This pull request should fix both and get the code ready for release.